### PR TITLE
SW-176662: Created kvm_x86_64 with latest 19.3 BoS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 build
 local.make
 onie-installer
+.idea/

--- a/installer/grub-arch/grub/grub-common.cfg
+++ b/installer/grub-arch/grub/grub-common.cfg
@@ -67,7 +67,7 @@ function onie_bootcmd {
   else
     onie_args="$GRUB_ONIE_CMDLINE_LINUX $ONIE_EXTRA_CMDLINE_LINUX"
   fi
-  linux   $onie_linux $onie_args boot_reason=$onie_boot_reason $onie_debugargs install_url=http://static-files.dev.drivenets.net/jammy-nos-installer-jenkins.sh
+  linux   $onie_linux $onie_args boot_reason=$onie_boot_reason $onie_debugargs install_url=http://static-files.dev.drivenets.net/baseos/defualt-nos-instlaller-bosvm.sh
   initrd  $onie_initrd
   onie_entry_end
   boot

--- a/machine/kvm_x86_64/machine.make
+++ b/machine/kvm_x86_64/machine.make
@@ -9,11 +9,15 @@
 
 ONIE_ARCH ?= x86_64
 
-VENDOR_REV ?= 0
+# SW-176662: Change in the installation URL pointed @installer/grub-arch/grub/grub-common.cfg
+# v19.3 BOS will be installed instead of outdated bionic
+VENDOR_REV ?= 1
 
 # Translate hardware revision to ONIE hardware revision
 ifeq ($(VENDOR_REV),0)
   MACHINE_REV = 0
+else ifeq ($(VENDOR_REV),1)
+  MACHINE_REV = 1
 else
   $(warning Unknown VENDOR_REV '$(VENDOR_REV)' for MACHINE '$(MACHINE)')
   $(error Unknown VENDOR_REV)


### PR DESCRIPTION
This BoS version, as opposed to the previous bionic one, is updated and contains TPM modules, required by DNOS v25.1 since SW-141111 (PR#72488).

Updated kvm_x86_64 to r1 to distinguish from previous image.